### PR TITLE
Repositories refactoring

### DIFF
--- a/src/Milax/Mconsole/API/Links.php
+++ b/src/Milax/Mconsole/API/Links.php
@@ -4,10 +4,19 @@ namespace Milax\Mconsole\API;
 
 use Milax\Mconsole\Contracts\API\GenericAPI;
 use Milax\Mconsole\Contracts\API\RepositoryAPI;
+use Milax\Mconsole\Contracts\Repositories\LinksRepository as Repository;
 use Request;
 
 class Links extends RepositoryAPI implements GenericAPI
 {
+    /**
+     * Create new instance
+     */
+    public function __consruct(Repository $repository)
+    {
+        $this->repository = $repository;
+    }
+    
     /**
      * Sync or detach links
      * 
@@ -23,10 +32,10 @@ class Links extends RepositoryAPI implements GenericAPI
         if ($links = Request::input('links')) {
             foreach (json_decode($links, true) as $link) {
                 if (isset($link['id']) && strlen($link['id']) > 0) {
-                    app('API')->repositories->links->update($link['id'], $link);
+                    $this->repository->update($link['id'], $link);
                     array_push($sync, $link['id']);
                 } else {
-                    array_push($sync, app('API')->repositories->links->create($link)->id);
+                    array_push($sync, $this->repository->create($link)->id);
                 }
             }
         }

--- a/src/Milax/Mconsole/API/Modules.php
+++ b/src/Milax/Mconsole/API/Modules.php
@@ -19,7 +19,7 @@ class Modules extends RepositoryAPI
     /**
      * Create new loader instance
      */
-    public function __construct($model, $provider = null)
+    public function __construct($model = null, $provider = null)
     {
         $this->model = $model;
         $this->provider = $provider;

--- a/src/Milax/Mconsole/Contracts/Repositories/LanguagesRepository.php
+++ b/src/Milax/Mconsole/Contracts/Repositories/LanguagesRepository.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Milax\Mconsole\Contracts\Repositories;
+
+interface LanguagesRepository
+{
+}

--- a/src/Milax/Mconsole/Contracts/Repositories/LinksRepository.php
+++ b/src/Milax/Mconsole/Contracts/Repositories/LinksRepository.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Milax\Mconsole\Contracts\Repositories;
+
+interface LinksRepository
+{
+}

--- a/src/Milax/Mconsole/Contracts/Repositories/MenusRepository.php
+++ b/src/Milax/Mconsole/Contracts/Repositories/MenusRepository.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Milax\Mconsole\Contracts\Repositories;
+
+interface MenusRepository
+{
+}

--- a/src/Milax/Mconsole/Contracts/Repositories/ModulesRepository.php
+++ b/src/Milax/Mconsole/Contracts/Repositories/ModulesRepository.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Milax\Mconsole\Contracts\Repositories;
+
+interface ModulesRepository
+{
+}

--- a/src/Milax/Mconsole/Contracts/Repositories/PresetsRepository.php
+++ b/src/Milax/Mconsole/Contracts/Repositories/PresetsRepository.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Milax\Mconsole\Contracts\Repositories;
+
+interface PresetsRepository
+{
+}

--- a/src/Milax/Mconsole/Contracts/Repositories/RolesRepository.php
+++ b/src/Milax/Mconsole/Contracts/Repositories/RolesRepository.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Milax\Mconsole\Contracts\Repositories;
+
+interface RolesRepository
+{
+}

--- a/src/Milax/Mconsole/Contracts/Repositories/SettingsRepository.php
+++ b/src/Milax/Mconsole/Contracts/Repositories/SettingsRepository.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Milax\Mconsole\Contracts\Repositories;
+
+interface SettingsRepository
+{
+}

--- a/src/Milax/Mconsole/Contracts/Repositories/TagsRepository.php
+++ b/src/Milax/Mconsole/Contracts/Repositories/TagsRepository.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Milax\Mconsole\Contracts\Repositories;
+
+interface TagsRepository
+{
+}

--- a/src/Milax/Mconsole/Contracts/Repositories/UploadsRepository.php
+++ b/src/Milax/Mconsole/Contracts/Repositories/UploadsRepository.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Milax\Mconsole\Contracts\Repositories;
+
+interface UploadsRepository
+{
+}

--- a/src/Milax/Mconsole/Contracts/Repositories/UsersRepository.php
+++ b/src/Milax/Mconsole/Contracts/Repositories/UsersRepository.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Milax\Mconsole\Contracts\Repositories;
+
+interface UsersRepository
+{
+}

--- a/src/Milax/Mconsole/Contracts/Repositories/VariablesRepository.php
+++ b/src/Milax/Mconsole/Contracts/Repositories/VariablesRepository.php
@@ -1,0 +1,7 @@
+<?php
+
+namespace Milax\Mconsole\Contracts\Repositories;
+
+interface VariablesRepository
+{
+}

--- a/src/Milax/Mconsole/Contracts/Repository.php
+++ b/src/Milax/Mconsole/Contracts/Repository.php
@@ -9,7 +9,7 @@ interface Repository
      * 
      * @param mixed $model [Model class]
      */
-    public function __construct($model);
+    public function __construct($model = null);
     
     /**
      * Set query

--- a/src/Milax/Mconsole/Http/Controllers/LanguagesController.php
+++ b/src/Milax/Mconsole/Http/Controllers/LanguagesController.php
@@ -6,7 +6,7 @@ use App\Http\Controllers\Controller;
 use Milax\Mconsole\Http\Requests\LanguageRequest;
 use Milax\Mconsole\Contracts\ListRenderer;
 use Milax\Mconsole\Contracts\FormRenderer;
-use Milax\Mconsole\Contracts\Repository;
+use Milax\Mconsole\Contracts\Repositories\LanguagesRepository as Repository;
 
 class LanguagesController extends Controller
 {

--- a/src/Milax/Mconsole/Http/Controllers/LanguagesController.php
+++ b/src/Milax/Mconsole/Http/Controllers/LanguagesController.php
@@ -6,7 +6,7 @@ use App\Http\Controllers\Controller;
 use Milax\Mconsole\Http\Requests\LanguageRequest;
 use Milax\Mconsole\Contracts\ListRenderer;
 use Milax\Mconsole\Contracts\FormRenderer;
-use Milax\Mconsole\Contracts\Repositories\LanguagesRepository as Repository;
+use Milax\Mconsole\Contracts\Repositories\LanguagesRepository;
 
 class LanguagesController extends Controller
 {
@@ -17,7 +17,7 @@ class LanguagesController extends Controller
     /**
      * Create new class instance
      */
-    public function __construct(ListRenderer $list, FormRenderer $form, Repository $repository)
+    public function __construct(ListRenderer $list, FormRenderer $form, LanguagesRepository $repository)
     {
         $this->setCaption(trans('mconsole::languages.menu.name'));
         $this->list = $list;

--- a/src/Milax/Mconsole/Http/Controllers/MenusController.php
+++ b/src/Milax/Mconsole/Http/Controllers/MenusController.php
@@ -7,7 +7,7 @@ use Milax\Mconsole\Http\Requests\MenuRequest;
 use Milax\Mconsole\Models\Menu;
 use Milax\Mconsole\Contracts\ListRenderer;
 use Milax\Mconsole\Contracts\FormRenderer;
-use Milax\Mconsole\Contracts\Repositories\MenusRepository as Repository;
+use Milax\Mconsole\Contracts\Repositories\MenusRepository;
 
 class MenusController extends Controller
 {
@@ -17,7 +17,7 @@ class MenusController extends Controller
     /**
      * Create new class instance
      */
-    public function __construct(ListRenderer $list, FormRenderer $form, Repository $repository)
+    public function __construct(ListRenderer $list, FormRenderer $form, MenusRepository $repository)
     {
         $this->setCaption(trans('mconsole::menus.menu.name'));
         $this->list = $list;

--- a/src/Milax/Mconsole/Http/Controllers/MenusController.php
+++ b/src/Milax/Mconsole/Http/Controllers/MenusController.php
@@ -7,7 +7,7 @@ use Milax\Mconsole\Http\Requests\MenuRequest;
 use Milax\Mconsole\Models\Menu;
 use Milax\Mconsole\Contracts\ListRenderer;
 use Milax\Mconsole\Contracts\FormRenderer;
-use Milax\Mconsole\Contracts\Repository;
+use Milax\Mconsole\Contracts\Repositories\MenusRepository as Repository;
 
 class MenusController extends Controller
 {

--- a/src/Milax/Mconsole/Http/Controllers/ModulesController.php
+++ b/src/Milax/Mconsole/Http/Controllers/ModulesController.php
@@ -8,7 +8,7 @@ use Milax\Mconsole\Models\MconsoleModule;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use Cache;
-use Milax\Mconsole\Contracts\Repository;
+use Milax\Mconsole\Contracts\Repositories\ModulesRepository as Repository;
 
 class ModulesController extends Controller
 {

--- a/src/Milax/Mconsole/Http/Controllers/ModulesController.php
+++ b/src/Milax/Mconsole/Http/Controllers/ModulesController.php
@@ -8,13 +8,13 @@ use Milax\Mconsole\Models\MconsoleModule;
 use GuzzleHttp\Client;
 use GuzzleHttp\Exception\RequestException;
 use Cache;
-use Milax\Mconsole\Contracts\Repositories\ModulesRepository as Repository;
+use Milax\Mconsole\Contracts\Repositories\ModulesRepository;
 
 class ModulesController extends Controller
 {
     use \UseLayout;
     
-    public function __construct(Repository $repository)
+    public function __construct(ModulesRepository $repository)
     {
         $this->setCaption(trans('mconsole::modules.menu.name'));
         $this->repository = $repository;

--- a/src/Milax/Mconsole/Http/Controllers/PresetsController.php
+++ b/src/Milax/Mconsole/Http/Controllers/PresetsController.php
@@ -9,7 +9,7 @@ use Milax\Mconsole\Models\MconsoleUploadPreset;
 use Milax\Mconsole\Contracts\Localizator;
 use Milax\Mconsole\Contracts\ListRenderer;
 use Milax\Mconsole\Contracts\FormRenderer;
-use Milax\Mconsole\Contracts\Repository;
+use Milax\Mconsole\Contracts\Repositories\PresetsRepository as Repository;
 
 class PresetsController extends Controller
 {

--- a/src/Milax/Mconsole/Http/Controllers/PresetsController.php
+++ b/src/Milax/Mconsole/Http/Controllers/PresetsController.php
@@ -9,7 +9,7 @@ use Milax\Mconsole\Models\MconsoleUploadPreset;
 use Milax\Mconsole\Contracts\Localizator;
 use Milax\Mconsole\Contracts\ListRenderer;
 use Milax\Mconsole\Contracts\FormRenderer;
-use Milax\Mconsole\Contracts\Repositories\PresetsRepository as Repository;
+use Milax\Mconsole\Contracts\Repositories\PresetsRepository;
 
 class PresetsController extends Controller
 {
@@ -20,7 +20,7 @@ class PresetsController extends Controller
     /**
      * Create new class instance
      */
-    public function __construct(ListRenderer $list, FormRenderer $form, Repository $repository)
+    public function __construct(ListRenderer $list, FormRenderer $form, PresetsRepository $repository)
     {
         $this->setCaption(trans('mconsole::presets.menu.name'));
         $this->list = $list;

--- a/src/Milax/Mconsole/Http/Controllers/RolesController.php
+++ b/src/Milax/Mconsole/Http/Controllers/RolesController.php
@@ -7,7 +7,7 @@ use Milax\Mconsole\Http\Requests\MconsoleRoleRequest;
 use Milax\Mconsole\Models\MconsoleRole;
 use Milax\Mconsole\Contracts\ListRenderer;
 use Milax\Mconsole\Contracts\FormRenderer;
-use Milax\Mconsole\Contracts\Repositories\RolesRepository as Repository;
+use Milax\Mconsole\Contracts\Repositories\RolesRepository;
 
 class RolesController extends Controller
 {
@@ -17,7 +17,7 @@ class RolesController extends Controller
     /**
      * Create new class instance
      */
-    public function __construct(ListRenderer $list, FormRenderer $form, Repository $repository)
+    public function __construct(ListRenderer $list, FormRenderer $form, RolesRepository $repository)
     {
         $this->setCaption(trans('mconsole::roles.menu.name'));
         $this->list = $list;

--- a/src/Milax/Mconsole/Http/Controllers/RolesController.php
+++ b/src/Milax/Mconsole/Http/Controllers/RolesController.php
@@ -7,7 +7,7 @@ use Milax\Mconsole\Http\Requests\MconsoleRoleRequest;
 use Milax\Mconsole\Models\MconsoleRole;
 use Milax\Mconsole\Contracts\ListRenderer;
 use Milax\Mconsole\Contracts\FormRenderer;
-use Milax\Mconsole\Contracts\Repository;
+use Milax\Mconsole\Contracts\Repositories\RolesRepository as Repository;
 
 class RolesController extends Controller
 {

--- a/src/Milax/Mconsole/Http/Controllers/SettingsController.php
+++ b/src/Milax/Mconsole/Http/Controllers/SettingsController.php
@@ -6,7 +6,7 @@ use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use Milax\Mconsole\Models\MconsoleOption;
 use Milax\Mconsole\Http\Requests\SettingsRequest;
-use Milax\Mconsole\Contracts\Repository;
+use Milax\Mconsole\Contracts\Repositories\SettingsRepository as Repository;
 
 class SettingsController extends Controller
 {

--- a/src/Milax/Mconsole/Http/Controllers/SettingsController.php
+++ b/src/Milax/Mconsole/Http/Controllers/SettingsController.php
@@ -6,13 +6,13 @@ use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use Milax\Mconsole\Models\MconsoleOption;
 use Milax\Mconsole\Http\Requests\SettingsRequest;
-use Milax\Mconsole\Contracts\Repositories\SettingsRepository as Repository;
+use Milax\Mconsole\Contracts\Repositories\SettingsRepository;
 
 class SettingsController extends Controller
 {
     use \UseLayout;
     
-    public function __construct(Repository $repository)
+    public function __construct(SettingsRepository $repository)
     {
         $this->setCaption(trans('mconsole::settings.menu.name'));
         $this->repository = $repository;

--- a/src/Milax/Mconsole/Http/Controllers/TagsController.php
+++ b/src/Milax/Mconsole/Http/Controllers/TagsController.php
@@ -7,7 +7,7 @@ use Milax\Mconsole\Http\Requests\TagRequest;
 use Milax\Mconsole\Models\Tag;
 use Milax\Mconsole\Contracts\ListRenderer;
 use Milax\Mconsole\Contracts\FormRenderer;
-use Milax\Mconsole\Contracts\Repository;
+use Milax\Mconsole\Contracts\Repositories\TagsRepository;
 
 class TagsController extends Controller
 {
@@ -18,7 +18,7 @@ class TagsController extends Controller
     /**
      * Create new class instance
      */
-    public function __construct(ListRenderer $list, FormRenderer $form, Repository $repository)
+    public function __construct(ListRenderer $list, FormRenderer $form, TagsRepository $repository)
     {
         $this->setCaption(trans('mconsole::tags.menu.name'));
         $this->list = $list;

--- a/src/Milax/Mconsole/Http/Controllers/TagsController.php
+++ b/src/Milax/Mconsole/Http/Controllers/TagsController.php
@@ -7,7 +7,7 @@ use Milax\Mconsole\Http\Requests\TagRequest;
 use Milax\Mconsole\Models\Tag;
 use Milax\Mconsole\Contracts\ListRenderer;
 use Milax\Mconsole\Contracts\FormRenderer;
-use Milax\Mconsole\Contracts\Repositories\TagsRepository;
+use Milax\Mconsole\Contracts\Repositories\TagsRepository as Repository;
 
 class TagsController extends Controller
 {
@@ -18,7 +18,7 @@ class TagsController extends Controller
     /**
      * Create new class instance
      */
-    public function __construct(ListRenderer $list, FormRenderer $form, TagsRepository $repository)
+    public function __construct(ListRenderer $list, FormRenderer $form, Repository $repository)
     {
         $this->setCaption(trans('mconsole::tags.menu.name'));
         $this->list = $list;

--- a/src/Milax/Mconsole/Http/Controllers/TagsController.php
+++ b/src/Milax/Mconsole/Http/Controllers/TagsController.php
@@ -7,7 +7,7 @@ use Milax\Mconsole\Http\Requests\TagRequest;
 use Milax\Mconsole\Models\Tag;
 use Milax\Mconsole\Contracts\ListRenderer;
 use Milax\Mconsole\Contracts\FormRenderer;
-use Milax\Mconsole\Contracts\Repositories\TagsRepository as Repository;
+use Milax\Mconsole\Contracts\Repositories\TagsRepository;
 
 class TagsController extends Controller
 {
@@ -18,7 +18,7 @@ class TagsController extends Controller
     /**
      * Create new class instance
      */
-    public function __construct(ListRenderer $list, FormRenderer $form, Repository $repository)
+    public function __construct(ListRenderer $list, FormRenderer $form, TagsRepository $repository)
     {
         $this->setCaption(trans('mconsole::tags.menu.name'));
         $this->list = $list;

--- a/src/Milax/Mconsole/Http/Controllers/UploadsController.php
+++ b/src/Milax/Mconsole/Http/Controllers/UploadsController.php
@@ -5,7 +5,7 @@ namespace Milax\Mconsole\Http\Controllers;
 use App\Http\Controllers\Controller;
 use Milax\Mconsole\Models\Upload;
 use Milax\Mconsole\Contracts\ListRenderer;
-use Milax\Mconsole\Contracts\Repositories\UploadsRepository as Repository;
+use Milax\Mconsole\Contracts\Repositories\UploadsRepository;
 
 class UploadsController extends Controller
 {
@@ -16,7 +16,7 @@ class UploadsController extends Controller
     /**
      * Create new class instance
      */
-    public function __construct(ListRenderer $renderer, Repository $repository)
+    public function __construct(ListRenderer $renderer, UploadsRepository $repository)
     {
         $this->setCaption(trans('mconsole::uploads.menu.name'));
         $this->renderer = $renderer;

--- a/src/Milax/Mconsole/Http/Controllers/UploadsController.php
+++ b/src/Milax/Mconsole/Http/Controllers/UploadsController.php
@@ -5,7 +5,7 @@ namespace Milax\Mconsole\Http\Controllers;
 use App\Http\Controllers\Controller;
 use Milax\Mconsole\Models\Upload;
 use Milax\Mconsole\Contracts\ListRenderer;
-use Milax\Mconsole\Contracts\Repository;
+use Milax\Mconsole\Contracts\Repositories\UploadsRepository as Repository;
 
 class UploadsController extends Controller
 {

--- a/src/Milax/Mconsole/Http/Controllers/UsersController.php
+++ b/src/Milax/Mconsole/Http/Controllers/UsersController.php
@@ -9,7 +9,7 @@ use App\User;
 use Milax\Mconsole\Models\MconsoleRole;
 use Milax\Mconsole\Contracts\ListRenderer;
 use Milax\Mconsole\Contracts\FormRenderer;
-use Milax\Mconsole\Contracts\Repository;
+use Milax\Mconsole\Contracts\Repositories\UsersRepository as Repository;
 
 class UsersController extends Controller
 {

--- a/src/Milax/Mconsole/Http/Controllers/UsersController.php
+++ b/src/Milax/Mconsole/Http/Controllers/UsersController.php
@@ -9,7 +9,8 @@ use App\User;
 use Milax\Mconsole\Models\MconsoleRole;
 use Milax\Mconsole\Contracts\ListRenderer;
 use Milax\Mconsole\Contracts\FormRenderer;
-use Milax\Mconsole\Contracts\Repositories\UsersRepository as Repository;
+use Milax\Mconsole\Contracts\Repositories\UsersRepository;
+use Milax\Mconsole\Contracts\Repositories\RolesRepository;
 
 class UsersController extends Controller
 {
@@ -20,15 +21,15 @@ class UsersController extends Controller
     /**
      * Create new class instance
      */
-    public function __construct(ListRenderer $list, FormRenderer $form, Repository $repository)
+    public function __construct(ListRenderer $list, FormRenderer $form, UsersRepository $repository, RolesRepository $roles)
     {
         $this->setCaption(trans('mconsole::users.menu.name'));
         $this->list = $list;
         $this->form = $form;
         $this->repository = $repository;
+        $this->roles = $roles;
         
         $this->redirectTo = mconsole_url('users');
-        $this->roles = app('API')->repositories->roles;
         $this->roles = $this->roles->query()->notRoot()->get()->lists('name', 'id');
         $this->roles->prepend(trans('mconsole::users.types.generic'), 0);
     }

--- a/src/Milax/Mconsole/Http/Controllers/VariablesController.php
+++ b/src/Milax/Mconsole/Http/Controllers/VariablesController.php
@@ -5,13 +5,13 @@ namespace Milax\Mconsole\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use Milax\Mconsole\Models\Variable;
-use Milax\Mconsole\Contracts\Repositories\VariablesRepository as Repository;
+use Milax\Mconsole\Contracts\Repositories\VariablesRepository;
 
 class VariablesController extends Controller
 {
     use \UseLayout;
     
-    public function __construct(Repository $repository)
+    public function __construct(VariablesRepository $repository)
     {
         $this->setCaption(trans('mconsole::variables.menu.name'));
         $this->repository = $repository;

--- a/src/Milax/Mconsole/Http/Controllers/VariablesController.php
+++ b/src/Milax/Mconsole/Http/Controllers/VariablesController.php
@@ -5,13 +5,13 @@ namespace Milax\Mconsole\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use Milax\Mconsole\Models\Variable;
-use Milax\Mconsole\Contracts\Repository;
+use Milax\Mconsole\Contracts\Repositories\VariablesRepository;
 
 class VariablesController extends Controller
 {
     use \UseLayout;
     
-    public function __construct(Repository $repository)
+    public function __construct(VariablesRepository $repository)
     {
         $this->setCaption(trans('mconsole::variables.menu.name'));
         $this->repository = $repository;

--- a/src/Milax/Mconsole/Http/Controllers/VariablesController.php
+++ b/src/Milax/Mconsole/Http/Controllers/VariablesController.php
@@ -5,13 +5,13 @@ namespace Milax\Mconsole\Http\Controllers;
 use Illuminate\Http\Request;
 use App\Http\Controllers\Controller;
 use Milax\Mconsole\Models\Variable;
-use Milax\Mconsole\Contracts\Repositories\VariablesRepository;
+use Milax\Mconsole\Contracts\Repositories\VariablesRepository as Repository;
 
 class VariablesController extends Controller
 {
     use \UseLayout;
     
-    public function __construct(VariablesRepository $repository)
+    public function __construct(Repository $repository)
     {
         $this->setCaption(trans('mconsole::variables.menu.name'));
         $this->repository = $repository;

--- a/src/Milax/Mconsole/Http/Requests/LanguageRequest.php
+++ b/src/Milax/Mconsole/Http/Requests/LanguageRequest.php
@@ -3,15 +3,16 @@
 namespace Milax\Mconsole\Http\Requests;
 
 use App\Http\Requests\Request;
+use Milax\Mconsole\Contracts\Repositories\LanguagesRepository;
 
 class LanguageRequest extends Request
 {
     /**
      * Create new instance
      */
-    public function __construct()
+    public function __construct(LanguagesRepository $repository)
     {
-        $this->repository = app('API')->repositories->languages;
+        $this->repository = $repository;
     }
     
     /**

--- a/src/Milax/Mconsole/Providers/RepositoriesServiceProvider.php
+++ b/src/Milax/Mconsole/Providers/RepositoriesServiceProvider.php
@@ -16,94 +16,16 @@ class RepositoriesServiceProvider extends ServiceProvider
     
     public function register()
     {
-        $repositories = [
-            [
-                'when' => '\Milax\Mconsole\Http\Controllers\MenusController',
-                'needs' => '\Milax\Mconsole\Contracts\Repository',
-                'give' => function () {
-                    return new \Milax\Mconsole\Repositories\MenusRepository(\Milax\Mconsole\Models\Menu::class);
-                },
-                'bind' => 'menus',
-            ],
-            [
-                'when' => '\Milax\Mconsole\Http\Controllers\PresetsController',
-                'needs' => '\Milax\Mconsole\Contracts\Repository',
-                'give' => function () {
-                    return new \Milax\Mconsole\Repositories\PresetsRepository(\Milax\Mconsole\Models\MconsoleUploadPreset::class);
-                },
-                'bind' => 'presets',
-            ],
-            [
-                'when' => '\Milax\Mconsole\Http\Controllers\RolesController',
-                'needs' => '\Milax\Mconsole\Contracts\Repository',
-                'give' => function () {
-                    return new \Milax\Mconsole\Repositories\RolesRepository(\Milax\Mconsole\Models\MconsoleRole::class);
-                },
-                'bind' => 'roles',
-            ],
-            [
-                'when' => '\Milax\Mconsole\Http\Controllers\TagsController',
-                'needs' => '\Milax\Mconsole\Contracts\Repository',
-                'give' => function () {
-                    return new \Milax\Mconsole\Repositories\TagsRepository(\Milax\Mconsole\Models\Tag::class);
-                },
-                'bind' => 'tags',
-            ],
-            [
-                'when' => '\Milax\Mconsole\Http\Controllers\UploadsController',
-                'needs' => '\Milax\Mconsole\Contracts\Repository',
-                'give' => function () {
-                    return new \Milax\Mconsole\Repositories\UploadsRepository(\Milax\Mconsole\Models\Upload::class);
-                },
-                'bind' => 'uploads',
-            ],
-            [
-                'when' => '\Milax\Mconsole\Http\Controllers\UsersController',
-                'needs' => '\Milax\Mconsole\Contracts\Repository',
-                'give' => function () {
-                    return new \Milax\Mconsole\Repositories\UsersRepository(\App\User::class);
-                },
-                'bind' => 'users',
-            ],
-            [
-                'when' => '\Milax\Mconsole\Http\Controllers\SettingsController',
-                'needs' => '\Milax\Mconsole\Contracts\Repository',
-                'give' => function () {
-                    return new \Milax\Mconsole\Repositories\SettingsRepository(\Milax\Mconsole\Models\MconsoleOption::class);
-                },
-                'bind' => 'settings',
-            ],
-            [
-                'when' => '\Milax\Mconsole\Http\Controllers\VariablesController',
-                'needs' => '\Milax\Mconsole\Contracts\Repository',
-                'give' => function () {
-                    return new \Milax\Mconsole\Repositories\VariablesRepository(\Milax\Mconsole\Models\Variable::class);
-                },
-                'bind' => 'variables',
-            ],
-            [
-                'when' => '\Milax\Mconsole\Http\Controllers\ModulesController',
-                'needs' => '\Milax\Mconsole\Contracts\Repository',
-                'give' => function () {
-                    return new \Milax\Mconsole\Repositories\ModulesRepository(\Milax\Mconsole\Models\MconsoleModule::class);
-                },
-                'bind' => 'modules',
-            ],
-            [
-                'when' => '\Milax\Mconsole\Http\Controllers\LanguagesController',
-                'needs' => '\Milax\Mconsole\Contracts\Repository',
-                'give' => function () {
-                    return new \Milax\Mconsole\Repositories\LanguagesRepository(\Milax\Mconsole\Models\Language::class);
-                },
-                'bind' => 'languages',
-            ],
-        ];
-        
-        // Repositories contextual binding
-        foreach ($repositories as $repository) {
-            app('API')->repositories->register($repository['bind'], $repository['give']());
-            $this->app->when($repository['when'])->needs($repository['needs'])->give($repository['give']);
-        }
-        app('API')->repositories->register('links', new \Milax\Mconsole\Repositories\LinksRepository(\Milax\Mconsole\Models\Link::class));
+        $this->app->bind('Milax\Mconsole\Contracts\Repositories\LanguagesRepository', 'Milax\Mconsole\Repositories\LanguagesRepository');
+        $this->app->bind('Milax\Mconsole\Contracts\Repositories\LinksRepository', 'Milax\Mconsole\Repositories\LinksRepository');
+        $this->app->bind('Milax\Mconsole\Contracts\Repositories\MenusRepository', 'Milax\Mconsole\Repositories\MenusRepository');
+        $this->app->bind('Milax\Mconsole\Contracts\Repositories\ModulesRepository', 'Milax\Mconsole\Repositories\ModulesRepository');
+        $this->app->bind('Milax\Mconsole\Contracts\Repositories\PresetsRepository', 'Milax\Mconsole\Repositories\PresetsRepository');
+        $this->app->bind('Milax\Mconsole\Contracts\Repositories\RolesRepository', 'Milax\Mconsole\Repositories\RolesRepository');
+        $this->app->bind('Milax\Mconsole\Contracts\Repositories\TagsRepository', 'Milax\Mconsole\Repositories\TagsRepository');
+        $this->app->bind('Milax\Mconsole\Contracts\Repositories\UploadsRepository', 'Milax\Mconsole\Repositories\UploadsRepository');
+        $this->app->bind('Milax\Mconsole\Contracts\Repositories\UsersRepository', 'Milax\Mconsole\Repositories\UsersRepository');
+        $this->app->bind('Milax\Mconsole\Contracts\Repositories\SettingsRepository', 'Milax\Mconsole\Repositories\SettingsRepository');
+        $this->app->bind('Milax\Mconsole\Contracts\Repositories\VariablesRepository', 'Milax\Mconsole\Repositories\VariablesRepository');
     }
 }

--- a/src/Milax/Mconsole/Repositories/EloquentRepository.php
+++ b/src/Milax/Mconsole/Repositories/EloquentRepository.php
@@ -11,9 +11,13 @@ abstract class EloquentRepository implements Repository
 {
     public $model;
     
-    public function __construct($model)
+    public function __construct($model = null)
     {
-        $this->model = $model;
+        if ($model) {
+            $this->model = $model;
+        }
+        
+        $model = $this->model;
         $this->query = $model::query();
     }
     

--- a/src/Milax/Mconsole/Repositories/LanguagesRepository.php
+++ b/src/Milax/Mconsole/Repositories/LanguagesRepository.php
@@ -3,7 +3,9 @@
 namespace Milax\Mconsole\Repositories;
 
 use Milax\Mconsole\Repositories\EloquentRepository;
+use Milax\Mconsole\Contracts\Repositories\LanguagesRepository as Repository;
 
-class LanguagesRepository extends EloquentRepository
+class LanguagesRepository extends EloquentRepository implements Repository
 {
+    public $model = \Milax\Mconsole\Models\Language::class;
 }

--- a/src/Milax/Mconsole/Repositories/LinksRepository.php
+++ b/src/Milax/Mconsole/Repositories/LinksRepository.php
@@ -3,7 +3,9 @@
 namespace Milax\Mconsole\Repositories;
 
 use Milax\Mconsole\Repositories\EloquentRepository;
+use Milax\Mconsole\Contracts\Repositories\LinksRepository as Repository;
 
-class LinksRepository extends EloquentRepository
+class LinksRepository extends EloquentRepository implements Repository
 {
+    public $model = \Milax\Mconsole\Models\Link::class;
 }

--- a/src/Milax/Mconsole/Repositories/MenusRepository.php
+++ b/src/Milax/Mconsole/Repositories/MenusRepository.php
@@ -3,7 +3,9 @@
 namespace Milax\Mconsole\Repositories;
 
 use Milax\Mconsole\Repositories\EloquentRepository;
+use Milax\Mconsole\Contracts\Repositories\MenusRepository as Repository;
 
-class MenusRepository extends EloquentRepository
+class MenusRepository extends EloquentRepository implements MenusRepository
 {
+    public $model = \Milax\Mconsole\Models\Menu::class;
 }

--- a/src/Milax/Mconsole/Repositories/ModulesRepository.php
+++ b/src/Milax/Mconsole/Repositories/ModulesRepository.php
@@ -3,7 +3,9 @@
 namespace Milax\Mconsole\Repositories;
 
 use Milax\Mconsole\Repositories\EloquentRepository;
+use Milax\Mconsole\Contracts\Repositories\ModulesRepository as Repository;
 
-class ModulesRepository extends EloquentRepository
+class ModulesRepository extends EloquentRepository implements Repository
 {
+    public $model = \Milax\Mconsole\Models\MconsoleModule::class;
 }

--- a/src/Milax/Mconsole/Repositories/PresetsRepository.php
+++ b/src/Milax/Mconsole/Repositories/PresetsRepository.php
@@ -3,7 +3,9 @@
 namespace Milax\Mconsole\Repositories;
 
 use Milax\Mconsole\Repositories\EloquentRepository;
+use Milax\Mconsole\Contracts\Repositories\PresetsRepository as Repository;
 
-class PresetsRepository extends EloquentRepository
+class PresetsRepository extends EloquentRepository implements Repository
 {
+    public $model = \Milax\Mconsole\Models\MconsoleUploadPreset::class;
 }

--- a/src/Milax/Mconsole/Repositories/RolesRepository.php
+++ b/src/Milax/Mconsole/Repositories/RolesRepository.php
@@ -3,9 +3,12 @@
 namespace Milax\Mconsole\Repositories;
 
 use Milax\Mconsole\Repositories\EloquentRepository;
+use Milax\Mconsole\Contracts\Repositories\RolesRepository as Repository;
 
-class RolesRepository extends EloquentRepository
+class RolesRepository extends EloquentRepository implements Repository
 {
+    public $model = \Milax\Mconsole\Models\MconsoleRole::class;
+    
     public function index()
     {
         return $this->query()->notRoot();

--- a/src/Milax/Mconsole/Repositories/SettingsRepository.php
+++ b/src/Milax/Mconsole/Repositories/SettingsRepository.php
@@ -3,7 +3,9 @@
 namespace Milax\Mconsole\Repositories;
 
 use Milax\Mconsole\Repositories\EloquentRepository;
+use Milax\Mconsole\Contracts\Repositories\SettingsRepository as Repository;
 
-class SettingsRepository extends EloquentRepository
+class SettingsRepository extends EloquentRepository implements Repository
 {
+    public $model = \Milax\Mconsole\Models\MconsoleOption::class;
 }

--- a/src/Milax/Mconsole/Repositories/TagsRepository.php
+++ b/src/Milax/Mconsole/Repositories/TagsRepository.php
@@ -3,7 +3,9 @@
 namespace Milax\Mconsole\Repositories;
 
 use Milax\Mconsole\Repositories\EloquentRepository;
+use Milax\Mconsole\Contracts\Repositories\TagsRepository as Repository;
 
-class TagsRepository extends EloquentRepository
+class TagsRepository extends EloquentRepository implements Repository
 {
+    public $model = \Milax\Mconsole\Models\Tag::class;
 }

--- a/src/Milax/Mconsole/Repositories/UploadsRepository.php
+++ b/src/Milax/Mconsole/Repositories/UploadsRepository.php
@@ -3,7 +3,9 @@
 namespace Milax\Mconsole\Repositories;
 
 use Milax\Mconsole\Repositories\EloquentRepository;
+use Milax\Mconsole\Contracts\Repositories\UploadsRepository as Repository;
 
-class UploadsRepository extends EloquentRepository
+class UploadsRepository extends EloquentRepository implements Repository
 {
+    public $model = \Milax\Mconsole\Models\Upload::class;
 }

--- a/src/Milax/Mconsole/Repositories/UsersRepository.php
+++ b/src/Milax/Mconsole/Repositories/UsersRepository.php
@@ -3,7 +3,9 @@
 namespace Milax\Mconsole\Repositories;
 
 use Milax\Mconsole\Repositories\EloquentRepository;
+use Milax\Mconsole\Contracts\Repositories\UsersRepository as Repository;
 
-class UsersRepository extends EloquentRepository
+class UsersRepository extends EloquentRepository implements Repository
 {
+    public $model = \App\User::class;
 }

--- a/src/Milax/Mconsole/Repositories/VariablesRepository.php
+++ b/src/Milax/Mconsole/Repositories/VariablesRepository.php
@@ -3,7 +3,9 @@
 namespace Milax\Mconsole\Repositories;
 
 use Milax\Mconsole\Repositories\EloquentRepository;
+use Milax\Mconsole\Contracts\Repositories\VariablesRepository as Repository;
 
-class VariablesRepository extends EloquentRepository
+class VariablesRepository extends EloquentRepository implements Repository
 {
+    public $model = \Milax\Mconsole\Models\Variable::class;
 }


### PR DESCRIPTION
`app('API')->repositories` is **deprectaed**!

Use method injection from `Milax\Mconsole\Contracts\Repositories\` instead.

Remove all old contextual repositories bindings in all current modules.